### PR TITLE
Fixed spin label display to show leading zeros

### DIFF
--- a/tktimepicker/spinlabel.py
+++ b/tktimepicker/spinlabel.py
@@ -137,7 +137,7 @@ class SpinLabel(HoverClickLabel):
             self.updateLabel()
 
     def updateLabel(self):
-        self["text"] = f"{self.current_val}"
+        self["text"] = f"{self.current_val:02d}"
         self.event_generate("<<valueChanged>>")
 
     def value(self) -> str:


### PR DESCRIPTION
Added a formatting string so that the spinner displays with a leading zero.

This does not change the underlying data (it is still an integer), it just adds a leading zero when being displayed with a formatted string. This makes times like 3:05 look less strange (base branch displays them as "3:5")